### PR TITLE
Provides support to match characters in a word for a range of unicode…

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function checkWord(nodehun, word, callback) {
 }
 
 function trimWord(word) {
-    var matches = word.match(/^\W*(([a-z]\.){2,}|\w+|(\w.+\w))\W*$/i);
+    var matches = word.match(/^[^\wÀ-ÿ]*([\wÀ-ÿ]+)*[^\wÀ-ÿ]*$/i);
     word = (matches && matches[1]) || '';
 
     return word.replace(/^\d+$/, '');

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function checkWord(nodehun, word, callback) {
 }
 
 function trimWord(word) {
-    var matches = word.match(/^[^\wÀ-ÿ]*([\wÀ-ÿ]+)*[^\wÀ-ÿ]*$/i);
+    var matches = word.match(/^[^\wÀ-ÿ]*([\wÀ-ÿ.]+)*[^\wÀ-ÿ]*$/i);
     word = (matches && matches[1]) || '';
 
     return word.replace(/^\d+$/, '');


### PR DESCRIPTION
Provide support to match characters from other languages.

For example, in current regex, ^\W excludes Umlaut character at the start of the word. This new pattern should fix that issue and a step towards better support for other languages.